### PR TITLE
viv References::ProhibitRefChecks

### DIFF
--- a/lib/Perl/Critic/Policy/References/ProhibitRefChecks.pm
+++ b/lib/Perl/Critic/Policy/References/ProhibitRefChecks.pm
@@ -8,7 +8,7 @@ use Readonly;
 use Perl::Critic::Utils qw/:severities :classification/;
 use base 'Perl::Critic::Policy';
 
-our $VERSION = '0.001';
+our $VERSION = '0.0.1';
 
 Readonly::Scalar my $DESC  => q{Do not perform manual ref checks};
 Readonly::Scalar my $EXPL  => undef; # [ ];

--- a/lib/Perl/Critic/Policy/References/ProhibitRefChecks.pm
+++ b/lib/Perl/Critic/Policy/References/ProhibitRefChecks.pm
@@ -1,0 +1,189 @@
+package Perl::Critic::Policy::References::ProhibitRefChecks;
+
+use 5.010001;
+use strict;
+use warnings;
+use Readonly;
+
+use Perl::Critic::Utils qw/:severities :classification/;
+use base 'Perl::Critic::Policy';
+
+our $VERSION = '0.001';
+
+Readonly::Scalar my $DESC  => q{Do not perform manual ref checks};
+Readonly::Scalar my $EXPL  => undef; # [ ];
+
+####-----------------------------------------------------------------------------
+
+sub supported_parameters {
+	return (
+		{
+			name           => 'eq',
+			description    => 'Reference types that may be checked via string equality.',
+			default_string => '',
+			behavior       => 'string list',
+		},
+		{
+			name           => 'ne',
+			description    => 'Reference types that may be checked via string inequality.',
+			default_string => '',
+			behavior       => 'string list',
+		},
+		{
+			name           => 'regexp',
+			description    => 'Permit regular expression comparisons.',
+			default_string => '0',
+			behavior       => 'boolean',
+		},
+		{
+			name           => 'bareref',
+			description    => 'Permit a bare if(ref) style check.',
+			default_string => '0',
+			behavior       => 'boolean',
+		},
+	);
+}
+
+sub applies_to           { return 'PPI::Token::Word' }
+sub default_severity     { return $SEVERITY_MEDIUM   }
+sub default_themes       { return qw/cosmetic maintenance performance/ }
+
+#-----------------------------------------------------------------------------
+
+sub invalid {
+	my ($self,$elem,$note)=@_;
+	$note//='';
+	if($note) { $note=" ($note)" }
+	return $self->violation(sprintf("%s%s",$DESC,$note),$EXPL,$elem);
+}
+
+sub eqne {
+	my ($node)=@_;
+	if(!$node) { return }
+	if(!$node->isa('PPI::Token::Operator')) { return }
+	my $op=$node->content();
+	if(($op eq 'eq')||($op eq 'ne')) { return 1 }
+	return;
+}
+
+sub decompose {
+	my ($elem)=@_;
+	my %operator=map {$_=>undef} (qw/eq ne !~ =~ cmp/);
+	my ($node,$operator,$rhs)=($elem,undef,undef);
+	while($node) {
+		if($node->isa('PPI::Token::Operator') && exists($operator{$node->content()})) {
+			$operator=$node->content();
+			$rhs=$node->snext_sibling();
+			$node=0;
+		}
+		else { $node=$node->snext_sibling() }
+	}
+	if(!$rhs) { return ($operator) }
+	if($rhs->isa('PPI::Token::Quote')) { return ($operator,lc($rhs->string())) }
+	if($rhs->isa('PPI::Token::Word') && ($rhs->content() eq 'ref')) { return ($operator,'ref') }
+	return ($operator,$rhs->content());
+}
+
+sub violates {
+	my ($self,$elem,undef)=@_;
+	if(!$elem->isa('PPI::Token::Word')) { return }
+	if(!is_perl_builtin($elem))         { return }
+	if(!is_function_call($elem))        { return }
+	if($elem->content() ne 'ref')       { return }
+
+	# Already handled.
+	# No support for ('quoted' eq ref($x)) at this time.
+	if(eqne($elem->sprevious_sibling())){ return }
+
+	$$self{_eq}     //={};
+	$$self{_ne}     //={};
+	$$self{_regexp} //=0;
+	$$self{_bareref}//=0;
+
+	# Without options, 'ref' should never be called.
+	if(!%{$$self{_eq}} && !%{$$self{_ne}} && !$$self{_regexp} && !$$self{_bareref}) { return $self->invalid($elem) }
+
+	my ($operator,$rhs)=decompose($elem);
+
+	if(!$operator) {
+		if(!$$self{_bareref}) { return $self->invalid($elem,'bare ref check') }
+		return;
+	}
+	elsif($operator eq 'eq') {
+		$$self{_eqfold}//={map {lc($_)=>undef} keys(%{$$self{_eq}//{}})};
+		if(!exists($$self{_eqfold}{$rhs})) { return $self->invalid($elem,$rhs) }
+		return;
+	}
+	elsif($operator eq 'ne') {
+		$$self{_nefold}//={map {lc($_)=>undef} keys(%{$$self{_ne}//{}})};
+		if(!exists($$self{_nefold}{$rhs})) { return $self->invalid($elem,$rhs) }
+		return;
+	}
+	elsif(($operator eq '=~')||($operator eq '!~')) {
+		if(!$$self{_regexp}) { return $self->invalid($elem,$rhs) }
+		return;
+	}
+	else {
+		return $self->invalid($elem,$rhs);
+	}
+	return;
+}
+
+#-----------------------------------------------------------------------------
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Perl::Critic::Policy::References::ProhibitRefChecks - Write C<is_arrayref($var)> instead of C<ref($var) eq 'ARRAY'>.
+
+=head1 DESCRIPTION
+
+Checking references manually is less efficient that using L<Ref::Util> and prone to typos.
+
+	if(ref($var) eq 'ARRYA') # oops!
+	if(is_arrayref($var))    # ok
+
+	if(ref($var) ne 'HASH')  # no
+	if(!is_hashref($var))    # ok
+
+	if(ref($var))            # no
+	if(is_ref($var))         # ok
+
+=head1 CONFIGURATION
+
+Explicit strings may be permitted for checks of the form C<ref(...) eq 'string'>, or C<ref(...) ne 'string'>.  Entries are case insensitive and can be the core types or custom modules.
+
+	[References::ProhibitRefChecks]
+	eq = code
+	ne = code my::module
+
+As a special scenario, checks of the form C<ref(...) eq ref(...)> can be permitted with C<eq = ref>.  The same works for C<ne = ref>.
+
+Regular expression matches are violations by default.  To permit checks of the form C<ref(...) =~ /pattern/> or C<!~>:
+
+	[References::ProhibitRefChecks]
+	regexp = 1
+
+Since L<Ref::Util> provides C<is_ref>, in the default configuration the bare C<ref> call is rarely needed.  To specifically permit using direct C<ref(...)> calls:
+
+	[References::ProhibitRefChecks]
+	bareref = 1
+
+=head1 NOTES
+
+Comparisons to stored values or constants are not supported:  C<ref(...) eq $thing> and C<ref(...) eq HASH()> are violations.
+
+Lexicographic comparison via C<ref(...) cmp "string"> is a violation.
+
+In/equality checks are not bidirectional:  C<'HASH' eq ref(...)> will not be considered a violation.
+
+=head1 BUGS
+
+Named unary functions are not separately considered.  A call of C<lc(ref $x) eq "array"> is considered a "bare ref check", whereas C<lc ref($x) eq "array"> is considered an "eq ref check".
+
+=cut

--- a/t/perl/critic/policy/references/prohibitrefchecks.t
+++ b/t/perl/critic/policy/references/prohibitrefchecks.t
@@ -1,0 +1,280 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Perl::Critic;
+use Ref::Util;
+
+use Test::More tests=>11;
+
+my $failure=qr/Do not perform manual ref/;
+
+subtest 'Valid Ref::Util'=>sub {
+	plan tests=>384;
+	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::References::ProhibitRefChecks');
+	foreach my $whitespace ('',' ') {
+	foreach my $parens (0,1) {
+	foreach my $var ('$var','$array[0]','$hash{key}','$$sref','$$aref[0]','$$href{key}','$aref->[0]','$href->{key}') {
+	foreach my $op (' ','!') {
+	foreach my $type (qw/is_arrayref is_hashref is_scalarref is_coderef is_globref is_formatref/) {
+		my $code=sprintf('%s%s%s%s%s%s'
+			,$op
+			,$type
+			,$whitespace
+			,($parens?'(':($whitespace||' ')) # )
+			,$var # ( for next line
+			,($parens?')':'')
+			);
+		my $label=sprintf('%14s %s %12s %s%s'
+			,lc($type)
+			,$op
+			,$var
+			,($whitespace?'w':'')
+			,($parens?'p':'')
+			);
+		is_deeply([$critic->critique(\$code)],[],$code);
+	} } } } }
+};
+
+subtest 'Default eq/ne/regexp/bare'=>sub {
+	plan tests=>1409;
+	#
+	# Verify the fast-failure scenario first.
+	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::References::ProhibitRefChecks');
+	like(($critic->critique(\'if(ref $x)'))[0],$failure,'fast failure if(ref $x)');
+	#
+	$critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::References::ProhibitRefChecks',-params=>{eq=>'nothing'});
+	#
+	# eq/ne
+	foreach my $whitespace ('',' ') {
+	foreach my $parens (0,1) {
+	foreach my $var ('$var','$array[0]','$hash{key}','$$sref','$$aref[0]','$$href{key}','$aref->[0]','$href->{key}') {
+	foreach my $op (qw/eq ne/) {
+	foreach my $quote ("'",'"') {
+	foreach my $type (qw/ARRAY HASH SCALAR CODE GLOB FORMAT/) {
+		my $code=sprintf('ref%s%s%s%s %s %s%s%s'
+			,$whitespace
+			,($parens?'(':($whitespace||' ')) # )
+			,$var # ( for next line
+			,($parens?')':'')
+			,$op
+			,$quote
+			,$type
+			,$quote);
+		like(($critic->critique(\$code))[0],$failure,$code);
+	} } } } } }
+	#
+	# regexp
+	foreach my $whitespace ('',' ') {
+	foreach my $parens (0,1) {
+	foreach my $var ('$var','$array[0]','$hash{key}','$$sref','$$aref[0]','$$href{key}','$aref->[0]','$href->{key}') {
+	foreach my $op ('=~','!~') {
+	foreach my $type (map {"/$_/"} qw/ARRAY HASH SCALAR CODE GLOB FORMAT/) {
+		my $code=sprintf('ref%s%s%s%s %s%s%s'
+			,$whitespace
+			,($parens?'(':($whitespace||' ')) # )
+			,$var # ( for next line
+			,($parens?')':'')
+			,$op
+			,$whitespace
+			,$type);
+		like(($critic->critique(\$code))[0],$failure,$code);
+	} } } } }
+	#
+	# bare ref check
+	foreach my $condition (qw/if unless while function/) {
+	foreach my $whitespace ('',' ') {
+	foreach my $parens (0,1) {
+	foreach my $var ('$var','$array[0]','$hash{key}','$$sref','$$aref[0]','$$href{key}','$aref->[0]','$href->{key}') {
+	foreach my $op (' ','!') {
+		my $code=sprintf('%s(%sref%s%s%s%s)'
+			,$condition
+			,$op
+			,$whitespace
+			,($parens?'(':($whitespace||' ')) # )
+			,$var # ( for next line
+			,($parens?')':'')
+			);
+		like(($critic->critique(\$code))[0],$failure,$code);
+	} } } } }
+};
+
+subtest 'eq parameter'=>sub {
+	plan tests=>768;
+	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::References::ProhibitRefChecks',-params=>{eq=>'code'});
+	#
+	# eq/ne
+	foreach my $whitespace ('',' ') {
+	foreach my $parens (0,1) {
+	foreach my $var ('$var','$array[0]','$hash{key}','$$sref','$$aref[0]','$$href{key}','$aref->[0]','$href->{key}') {
+	foreach my $op (qw/eq ne/) {
+	foreach my $quote ("'",'"') {
+	foreach my $type (qw/ARRAY HASH SCALAR CODE GLOB FORMAT/) {
+		my $code=sprintf('ref%s%s%s%s %s %s%s%s'
+			,$whitespace
+			,($parens?'(':($whitespace||' ')) # )
+			,$var # ( for next line
+			,($parens?')':'')
+			,$op
+			,$quote
+			,$type
+			,$quote);
+		if(($op eq 'eq')&&($type eq 'CODE')) { is_deeply([$critic->critique(\$code)],[],$code) }
+		else { like(($critic->critique(\$code))[0],$failure,$code) }
+	} } } } } }
+};
+
+subtest 'ne parameter'=>sub {
+	plan tests=>768;
+	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::References::ProhibitRefChecks',-params=>{ne=>'code'});
+	#
+	# eq/ne
+	foreach my $whitespace ('',' ') {
+	foreach my $parens (0,1) {
+	foreach my $var ('$var','$array[0]','$hash{key}','$$sref','$$aref[0]','$$href{key}','$aref->[0]','$href->{key}') {
+	foreach my $op (qw/eq ne/) {
+	foreach my $quote ("'",'"') {
+	foreach my $type (qw/ARRAY HASH SCALAR CODE GLOB FORMAT/) {
+		my $code=sprintf('ref%s%s%s%s %s %s%s%s'
+			,$whitespace
+			,($parens?'(':($whitespace||' ')) # )
+			,$var # ( for next line
+			,($parens?')':'')
+			,$op
+			,$quote
+			,$type
+			,$quote);
+		if(($op eq 'ne')&&($type eq 'CODE')) { is_deeply([$critic->critique(\$code)],[],$code) }
+		else { like(($critic->critique(\$code))[0],$failure,$code) }
+	} } } } } }
+};
+
+subtest 'regexp parameter'=>sub {
+	plan tests=>384;
+	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::References::ProhibitRefChecks',-params=>{regexp=>1});
+	#
+	# regexp
+	foreach my $whitespace ('',' ') {
+	foreach my $parens (0,1) {
+	foreach my $var ('$var','$array[0]','$hash{key}','$$sref','$$aref[0]','$$href{key}','$aref->[0]','$href->{key}') {
+	foreach my $op ('=~','!~') {
+	foreach my $type (map {"/$_/"} qw/ARRAY HASH SCALAR CODE GLOB FORMAT/) {
+		my $code=sprintf('ref%s%s%s%s %s%s%s'
+			,$whitespace
+			,($parens?'(':($whitespace||' ')) # )
+			,$var # ( for next line
+			,($parens?')':'')
+			,$op
+			,$whitespace
+			,$type);
+		is_deeply([$critic->critique(\$code)],[],$code);
+	} } } } }
+};
+
+subtest 'bareref parameter'=>sub {
+	plan tests=>256;
+	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::References::ProhibitRefChecks',-params=>{bareref=>1});
+	#
+	# bare ref check
+	foreach my $condition (qw/if unless while function/) {
+	foreach my $whitespace ('',' ') {
+	foreach my $parens (0,1) {
+	foreach my $var ('$var','$array[0]','$hash{key}','$$sref','$$aref[0]','$$href{key}','$aref->[0]','$href->{key}') {
+	foreach my $op (' ','!') {
+		my $code=sprintf('%s(%sref%s%s%s%s)'
+			,$condition
+			,$op
+			,$whitespace
+			,($parens?'(':($whitespace||' ')) # )
+			,$var # ( for next line
+			,($parens?')':'')
+			);
+		is_deeply([$critic->critique(\$code)],[],$code);
+	} } } } }
+};
+
+subtest 'ref eq ref'=>sub {
+	plan tests=>128;
+	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::References::ProhibitRefChecks',-params=>{eq=>'ref'});
+	#
+	# eq/ne
+	foreach my $whitespace ('',' ') {
+	foreach my $parens (0,1) {
+	foreach my $var ('$var','$array[0]','$hash{key}','$$sref','$$aref[0]','$$href{key}','$aref->[0]','$href->{key}') {
+	foreach my $op (qw/eq ne/) {
+	foreach my $rhs ('ref($x)','ref $x') {
+		my $code=sprintf('ref%s%s%s%s %s %s'
+			,$whitespace
+			,($parens?'(':($whitespace||' ')) # )
+			,$var # ( for next line
+			,($parens?')':'')
+			,$op
+			,$rhs);
+		if($op eq 'eq') { is_deeply([$critic->critique(\$code)],[],$code) }
+		else { like(($critic->critique(\$code))[0],$failure,$code) }
+	} } } } }
+};
+
+subtest 'ref ne ref'=>sub {
+	plan tests=>128;
+	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::References::ProhibitRefChecks',-params=>{ne=>'ref'});
+	#
+	# eq/ne
+	foreach my $whitespace ('',' ') {
+	foreach my $parens (0,1) {
+	foreach my $var ('$var','$array[0]','$hash{key}','$$sref','$$aref[0]','$$href{key}','$aref->[0]','$href->{key}') {
+	foreach my $op (qw/eq ne/) {
+	foreach my $rhs ('ref($x)','ref $x') {
+		my $code=sprintf('ref%s%s%s%s %s %s'
+			,$whitespace
+			,($parens?'(':($whitespace||' ')) # )
+			,$var # ( for next line
+			,($parens?')':'')
+			,$op
+			,$rhs);
+		if($op eq 'ne') { is_deeply([$critic->critique(\$code)],[],$code) }
+		else { like(($critic->critique(\$code))[0],$failure,$code) }
+	} } } } }
+};
+
+subtest 'Valid various'=>sub {
+	plan tests=>4;
+	my $code;
+	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::References::ProhibitRefChecks');
+	ok(join('',map {$_->get_themes()} $critic->policies()),'themes');
+	#
+	$code='$x=Module->ref($x)'; is_deeply([$critic->critique(\$code)],[],$code);
+	$code='sub ref { return }'; is_deeply([$critic->critique(\$code)],[],$code);
+	$code='if("ARRAY" eq ref($x))'; is_deeply([$critic->critique(\$code)],[],$code);
+};
+
+subtest 'Invalid various'=>sub {
+	plan tests=>6;
+	my $code;
+	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::References::ProhibitRefChecks',-params=>{eq=>'nothing'});
+	#
+	$code='if(ref($x) eq $string)';     like(($critic->critique(\$code))[0],$failure,$code);
+	$code='if(lc(ref($x)) eq "array")'; like(($critic->critique(\$code))[0],$failure,$code);
+	$code='if(lc ref($x)  eq "array")'; like(($critic->critique(\$code))[0],$failure,$code);
+	$code='if(ref($x) cmp "ARRAY")';    like(($critic->critique(\$code))[0],$failure,$code);
+	$code='if("ARRAY" cmp ref($x))';    like(($critic->critique(\$code))[0],$failure,$code);
+	$code='$s=ref($x).ref($y)';         like(($critic->critique(\$code))[0],$failure,$code);
+};
+
+subtest 'Other'=>sub {
+	plan tests=>1;
+	require Perl::Critic::Policy::References::ProhibitRefChecks;
+	ok(!Perl::Critic::Policy::References::ProhibitRefChecks::violates(undef,bless({},'PPI::Token')),'Only applies to Token::Word');
+};
+


### PR DESCRIPTION
```
PERL5LIB=lib prove t/perl/critic/policy/references/prohibitrefchecks.t
t/perl/critic/policy/references/prohibitrefchecks.t .. ok
All tests successful.
Files=1, Tests=11,  8 wallclock secs ( 0.40 usr  0.09 sys +  7.44 cusr  0.17 csys =  8.10 CPU)
Result: PASS

PERL5LIB=lib perlcritic --statistics-only --profile=./profileRefChecks.pro $DIR/*.pm
   240 files.
 1,013 subroutines/methods.
46,753 statements.

51,085 lines, consisting of:
     6,151 blank lines.
       809 comment lines.
         4 data lines.
    44,121 lines of Perl code.
         0 lines of POD.

Average McCabe score of subroutines was 7.23.

7 violations.
Violations per file was 0.029.
Violations per statement was 0.000.
Violations per line of code was 0.000.

7 severity 3 violations.

7 violations of References::ProhibitRefChecks.
```