### PR TITLE
viv CodeLayout::RequireParensWithBuiltins

### DIFF
--- a/lib/Perl/Critic/Policy/CodeLayout/RequireParensWithBuiltins.pm
+++ b/lib/Perl/Critic/Policy/CodeLayout/RequireParensWithBuiltins.pm
@@ -98,7 +98,7 @@ sub applies_to           { return 'PPI::Token::Word'  }
 
 sub violates {
 	my ($self,$elem,undef)=@_;
-	if(!is_perl_builtin($elem))                         { return }
+	if(!is_function_call($elem))                        { return }
 	if(!exists($$self{_operators}{ $elem->content() })) { return }
 	if(exists($$self{_allow}{ $elem->content() }))      { return }
 

--- a/lib/Perl/Critic/Policy/CodeLayout/RequireParensWithBuiltins.pm
+++ b/lib/Perl/Critic/Policy/CodeLayout/RequireParensWithBuiltins.pm
@@ -1,0 +1,156 @@
+package Perl::Critic::Policy::CodeLayout::RequireParensWithBuiltins;
+
+use 5.010001;
+use strict;
+use warnings;
+use Readonly;
+
+use Perl::Critic::Utils qw/ :severities :data_conversion :classification :language /;
+use base 'Perl::Critic::Policy';
+
+our $VERSION = '0.1.1';
+
+Readonly::Scalar my $DESC  => q{Builtin function called without parentheses};
+Readonly::Scalar my $EXPL  => [ 13 ];
+
+# One interpretation suggests that parentheses aren't needed when the function is followed
+# by an operator of lower precedence.  Since thi is less consistent, it has been removed
+# from the current implementation.
+# Readonly::Scalar my $lcprec => precedence_of(q{-e});
+
+Readonly::Array my @NAMED_UNARY_OPS => qw(
+	chdir
+	chroot
+	cos
+	glob
+	gmtime
+	hex
+	int
+	lc
+	lcfirst
+	length
+	localtime
+	log
+	lstat
+	oct
+	ord
+	quotemeta
+	rand
+	readlink
+	rmdir
+	sin
+	sleep
+	sqrt
+	srand
+	stat
+	uc
+	ucfirst
+	umask
+);
+Readonly::Hash my %NAMED_UNARY_OPS => hashify( @NAMED_UNARY_OPS );
+Readonly::Array my @ALLOW => qw(
+	alarm
+	caller
+	defined
+	delete
+	do
+	eval
+	exists
+	exit
+	getgrp
+	gethostbyname
+	getnetbyname
+	getprotobyname
+	lock
+	my
+	ref
+	require
+	return
+	scalar
+	undef
+);
+Readonly::Hash my %ALLOW => hashify( @ALLOW );
+
+####-----------------------------------------------------------------------------
+
+sub supported_parameters {
+	return (
+		{
+			name           => 'operators',
+			description    => 'The unary operators that should be restricted.',
+			default_string => join(' ',grep {!exists($ALLOW{$_})} @NAMED_UNARY_OPS),
+			behavior       => 'string list',
+		},
+		{
+			name           => 'allow',
+			description    => 'The unary operators that should be ignored.',
+			default_string => join(' ', @ALLOW),
+			behavior       => 'string list',
+		},
+	);
+}
+
+sub default_severity     { return $SEVERITY_HIGH      }
+sub default_themes       { return qw( core cosmetic ) }
+sub applies_to           { return 'PPI::Token::Word'  }
+
+#-----------------------------------------------------------------------------
+
+sub violates {
+	my ($self,$elem,undef)=@_;
+	if(!is_perl_builtin($elem))                         { return }
+	if(!exists($$self{_operators}{ $elem->content() })) { return }
+	if(exists($$self{_allow}{ $elem->content() }))      { return }
+
+	my $sibling=$elem->snext_sibling();
+	if(!$sibling||!$sibling->isa('PPI::Structure::List')) { return $self->violation(sprintf("$DESC (%s)",$elem->content()),$EXPL,$elem) }
+	return;
+}
+
+#-----------------------------------------------------------------------------
+
+1;
+
+__END__
+
+
+=pod
+
+=head1 NAME
+
+Perl::Critic::Policy::CodeLayout::RequireParensWithBuiltins - Write C<lc($x // "Default")> instead of C<lc $x // "Default">.
+
+=head1 DESCRIPTION
+
+String folding is often used in map lookups where missing parentheses may not provide the expected behavior
+
+	$LOOKUP{ lc $name // 'Default' }
+	$LOOKUP{ lc( $name // 'Default' ) }
+
+When C<$name> is undefined, the first form will lookup the value for C<""> (the empty string) and throw warnings from the C<lc> call.  The second form will lookup the value for C<"default">.  As an alternative approach
+
+	$LOOKUP{ lc($name) || 'Default' }
+
+will lookup the value for C<"default"> when C<$name> is undefined, but will still throw warnings from C<lc>.
+
+=head1 CONFIGURATION
+
+The named unary operators checked by the policy can be listed explicitly.
+
+	[CodeLayout::RequireParensWithBuiltins]
+	operators = lc lcfirst uc ucfirst
+
+The default list includes most string and mathematical operators, but excludes certain system calls and block operators.  Specific named operators can be excluded:
+
+	[CodeLayout::RequireParensWithBuiltins]
+	allow = sqrt
+
+=head1 NOTES
+
+While coding with parentheses can sometimes lead to verbose constructs, a single case without parentheses can lead to invalid data in processing and results.  For these functions, the lack of parentheses causes ambiguity so they can be considered F<necessary>.  Code maintainability must also support quick insert of defaults and handling of warnings for undefined values, so calls without those mechanisms are likely incorrect F<from the start>.
+
+=head1 BUGS
+
+It's possible that some mathematical functions are more natural without parentheses even when followed by lower-precedence operators.  The current policy makes no special exemptions for different precedence interpretations for different functions.
+
+=cut

--- a/lib/Perl/Critic/Policy/CodeLayout/RequireParensWithBuiltins.pm
+++ b/lib/Perl/Critic/Policy/CodeLayout/RequireParensWithBuiltins.pm
@@ -8,83 +8,74 @@ use Readonly;
 use Perl::Critic::Utils qw/ :severities :data_conversion :classification :language /;
 use base 'Perl::Critic::Policy';
 
-our $VERSION = '0.1.1';
+our $VERSION = '0.1.2';
 
 Readonly::Scalar my $DESC  => q{Builtin function called without parentheses};
 Readonly::Scalar my $EXPL  => [ 13 ];
 
-# One interpretation suggests that parentheses aren't needed when the function is followed
-# by an operator of lower precedence.  Since thi is less consistent, it has been removed
-# from the current implementation.
-# Readonly::Scalar my $lcprec => precedence_of(q{-e});
+# In each section, the order follows that of perlfunc(1).
+# Some keywords may be repeated if they appear in multiple perlfunc sections.
 
-Readonly::Array my @NAMED_UNARY_OPS => qw(
-	chdir
-	chroot
-	cos
-	glob
-	gmtime
-	hex
-	int
-	lc
-	lcfirst
-	length
-	localtime
-	log
-	lstat
-	oct
-	ord
-	quotemeta
-	rand
-	readlink
-	rmdir
-	sin
-	sleep
-	sqrt
-	srand
-	stat
-	uc
-	ucfirst
-	umask
-);
-Readonly::Hash my %NAMED_UNARY_OPS => hashify( @NAMED_UNARY_OPS );
-Readonly::Array my @ALLOW => qw(
-	alarm
+Readonly::Array my @REQUIRED => qw/
+	chr crypt fc hex index lc lcfirst length oct ord pack rindex sprintf substr uc ucfirst
+	quotemeta split study
+	abs atan2 cos exp hex int log oct rand sin sqrt srand
+	splice
+	join unpack
+	delete exists
+	binmode close closedir fileno flock read readdir readline rewinddir seek seekdir select syscall sysread sysseek syswrite tell telldir truncate warn write
+	pack read syscall sysread sysseek syswrite unpack vec
+	chdir chmod chown chroot fcntl glob ioctl link lstat mkdir open opendir readlink rename rmdir select stat symlink sysopen umask unlink utime
 	caller
-	defined
-	delete
-	do
-	eval
-	exists
+	formline lock scalar undef
+	alarm exec getpriority kill pipe readpipe setpgrp setpriority sleep system waitpid
+	bless ref tie tied untie
+	accept bind connect getpeername getsockname getsockopt listen recv send setsockopt shutdown socket socketpair
+/;
+
+Readonly::Array my @PERMITTED => qw/
+	chomp chop
+	pos
+	eof getc
 	exit
-	getgrp
-	gethostbyname
-	getnetbyname
-	getprotobyname
-	lock
-	my
-	ref
-	require
-	return
-	scalar
-	undef
-);
-Readonly::Hash my %ALLOW => hashify( @ALLOW );
+	defined reset
+	getpgrp
+	gmtime localtime time
+/;
+
+Readonly::Array my @ALLOWED => qw/
+	reverse
+	each keys pop push shift unshift values
+	each keys values
+	grep map reverse sort
+	die format print printf say
+	break continue die do dump eval evalbytes goto last next redo return wantarray
+	import local my our package state use
+	fork getppid times wait
+	do import no package require use
+	package use
+/;
 
 ####-----------------------------------------------------------------------------
 
 sub supported_parameters {
 	return (
 		{
-			name           => 'operators',
-			description    => 'The unary operators that should be restricted.',
-			default_string => join(' ',grep {!exists($ALLOW{$_})} @NAMED_UNARY_OPS),
+			name           => 'require',
+			description    => 'Always require parentheses of these operators.',
+			default_string => join(' ',@REQUIRED),
+			behavior       => 'string list',
+		},
+		{
+			name           => 'permit',
+			description    => 'Require parentheses when called with a parameter.',
+			default_string => join(' ',@PERMITTED),
 			behavior       => 'string list',
 		},
 		{
 			name           => 'allow',
-			description    => 'The unary operators that should be ignored.',
-			default_string => join(' ', @ALLOW),
+			description    => 'Never require parentheses.',
+			default_string => join(' ', @ALLOWED),
 			behavior       => 'string list',
 		},
 	);
@@ -99,11 +90,26 @@ sub applies_to           { return 'PPI::Token::Word'  }
 sub violates {
 	my ($self,$elem,undef)=@_;
 	if(!is_function_call($elem))                        { return }
-	if(!exists($$self{_operators}{ $elem->content() })) { return }
 	if(exists($$self{_allow}{ $elem->content() }))      { return }
 
 	my $sibling=$elem->snext_sibling();
-	if(!$sibling||!$sibling->isa('PPI::Structure::List')) { return $self->violation(sprintf("$DESC (%s)",$elem->content()),$EXPL,$elem) }
+	if(exists($$self{_require}{ $elem->content() })) {
+		if(!$sibling||!$sibling->isa('PPI::Structure::List')) { return $self->violation(sprintf("$DESC (%s)",$elem->content()),$EXPL,$elem) }
+	}
+
+	if(!$sibling||$sibling->isa('PPI::Structure::List')) { return }
+
+	if(exists($$self{_permit}{ $elem->content() })) {
+		if(  $sibling->isa('PPI::Token::Number')
+			|| $sibling->isa('PPI::Token::Quote')
+			|| $sibling->isa('PPI::Token::QuoteLike')
+			|| $sibling->isa('PPI::Token::Symbol')
+		) {
+			return $self->violation(sprintf("$DESC (%s)",$elem->content()),$EXPL,$elem);
+		}
+		return;
+	}
+
 	return;
 }
 
@@ -112,7 +118,6 @@ sub violates {
 1;
 
 __END__
-
 
 =pod
 
@@ -135,15 +140,29 @@ will lookup the value for C<"default"> when C<$name> is undefined, but will stil
 
 =head1 CONFIGURATION
 
-The named unary operators checked by the policy can be listed explicitly.
+The priority for configuration is Allow, Required, Permitted.
 
-	[CodeLayout::RequireParensWithBuiltins]
-	operators = lc lcfirst uc ucfirst
+=head2 Allow
 
-The default list includes most string and mathematical operators, but excludes certain system calls and block operators.  Specific named operators can be excluded:
+Functions in the C<allow> section can be called with or without parentheses, no restriction.  This overrides all other configurations.
 
 	[CodeLayout::RequireParensWithBuiltins]
 	allow = sqrt
+
+=head2 Required
+
+Names configured in the C<require> section always require parentheses, even when called without arguments or inside blocks.  EG C<lc()> or C<grep {lc($_)}>.  This overrides the C<permit> option.
+
+	[CodeLayout::RequireParensWithBuiltins]
+	operators = lc lcfirst uc ucfirst
+	require = lc lcfirst uc ucfirst
+
+=head2 Required with arguments
+
+Some functions operate on C<$_> or other defaults and may be used without parameters.  If configured in the C<permit> section, the functions will require parentheses when called with a parameter.  EG both C<grep {defined} ...> and C<if(defined($x))> are valid, but C<if(defined $x)> is a violation.
+
+	[CodeLayout::RequireParensWithBuiltins]
+	permit = defined
 
 =head1 NOTES
 

--- a/t/perl/critic/policy/codelayout/requireparenswithbuiltins.t
+++ b/t/perl/critic/policy/codelayout/requireparenswithbuiltins.t
@@ -9,7 +9,7 @@ use Test::More tests=>2;
 my $failure=qr/Builtin.*without parentheses/;
 
 subtest 'Valid cases'=>sub {
-	plan tests=>8;
+	plan tests=>12;
 	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
 	$critic->add_policy(-policy=>'Perl::Critic::Policy::CodeLayout::RequireParensWithBuiltins',-params=>{allow=>'rand srand'});
 	foreach my $valid (
@@ -21,6 +21,10 @@ subtest 'Valid cases'=>sub {
 		['not mandatory',   'my $x=lc("hi");'],
 		['not builtin',     'my $x=function "hi";'],
 		['allowed rand',    'my $x=rand 5;'],
+		['subroutine',      'sub log {1}'],
+		['method bare',     'my $x=$module->log;'],
+		['method child',    'my $x=$module->log->thing();'],
+		['key',             'my %hash=(one=>1,log=>0,two=>2);'],
 	) {
 		is_deeply([$critic->critique(\$$valid[1])],[],$$valid[0]);
 	}

--- a/t/perl/critic/policy/codelayout/requireparenswithbuiltins.t
+++ b/t/perl/critic/policy/codelayout/requireparenswithbuiltins.t
@@ -1,0 +1,48 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Perl::Critic;
+
+use Test::More tests=>2;
+
+my $failure=qr/Builtin.*without parentheses/;
+
+subtest 'Valid cases'=>sub {
+	plan tests=>8;
+	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::CodeLayout::RequireParensWithBuiltins',-params=>{allow=>'rand srand'});
+	foreach my $valid (
+		['Fallback or',     'my $x=lc("hi"||"bye")'],
+		['Undefined or',    'my $x=uc("hi"//"bye")'],
+		['lt',              'my $x=lc("hi") lt lc("bye")'],
+		['cmp',             'my $x=lc("hi") cmp lc("bye")'],
+		['numeric <',       'my $x=int(5) < int(7)'],
+		['not mandatory',   'my $x=lc("hi");'],
+		['not builtin',     'my $x=function "hi";'],
+		['allowed rand',    'my $x=rand 5;'],
+	) {
+		is_deeply([$critic->critique(\$$valid[1])],[],$$valid[0]);
+	}
+};
+
+subtest 'Invalid cases'=>sub {
+	plan tests=>10;
+	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::CodeLayout::RequireParensWithBuiltins');
+	foreach my $invalid (
+		['Standalone',      'my $x=lc "hi";'],
+		['Fallback or',     'my $x=lc "hi"||"bye"'],
+		['Undefined or',    'my $x=uc "hi"//"bye"'],
+		['lt',              'my $x=lc "hi" lt lc "bye"'],
+		['cmp',             'my $x=lc "hi" cmp lc "bye"'],
+		['concat',          'my $x=lc "hi" . "bye"'],
+		['numeric <',       'my $x=int 5 < int 7'],
+		['topic input',     'my $x=rand'],
+		['topic input;',    'my $x=rand;'],
+		['topic input+',    'my $x=rand+5;'],
+	) {
+		like(($critic->critique(\$$invalid[1]))[0],$failure,$$invalid[0]);
+	}
+};
+

--- a/t/perl/critic/policy/codelayout/requireparenswithbuiltins.t
+++ b/t/perl/critic/policy/codelayout/requireparenswithbuiltins.t
@@ -4,14 +4,14 @@ use strict;
 use warnings;
 use Perl::Critic;
 
-use Test::More tests=>2;
+use Test::More tests=>4;
 
 my $failure=qr/Builtin.*without parentheses/;
 
-subtest 'Valid cases'=>sub {
-	plan tests=>12;
+subtest 'Required cases'=>sub {
+	plan tests=>20;
 	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
-	$critic->add_policy(-policy=>'Perl::Critic::Policy::CodeLayout::RequireParensWithBuiltins',-params=>{allow=>'rand srand'});
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::CodeLayout::RequireParensWithBuiltins',-params=>{});
 	foreach my $valid (
 		['Fallback or',     'my $x=lc("hi"||"bye")'],
 		['Undefined or',    'my $x=uc("hi"//"bye")'],
@@ -20,7 +20,7 @@ subtest 'Valid cases'=>sub {
 		['numeric <',       'my $x=int(5) < int(7)'],
 		['not mandatory',   'my $x=lc("hi");'],
 		['not builtin',     'my $x=function "hi";'],
-		['allowed rand',    'my $x=rand 5;'],
+		['rand',            'my $x=rand(5);'],
 		['subroutine',      'sub log {1}'],
 		['method bare',     'my $x=$module->log;'],
 		['method child',    'my $x=$module->log->thing();'],
@@ -28,23 +28,87 @@ subtest 'Valid cases'=>sub {
 	) {
 		is_deeply([$critic->critique(\$$valid[1])],[],$$valid[0]);
 	}
-};
-
-subtest 'Invalid cases'=>sub {
-	plan tests=>10;
-	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
-	$critic->add_policy(-policy=>'Perl::Critic::Policy::CodeLayout::RequireParensWithBuiltins');
 	foreach my $invalid (
-		['Standalone',      'my $x=lc "hi";'],
 		['Fallback or',     'my $x=lc "hi"||"bye"'],
 		['Undefined or',    'my $x=uc "hi"//"bye"'],
 		['lt',              'my $x=lc "hi" lt lc "bye"'],
 		['cmp',             'my $x=lc "hi" cmp lc "bye"'],
-		['concat',          'my $x=lc "hi" . "bye"'],
 		['numeric <',       'my $x=int 5 < int 7'],
-		['topic input',     'my $x=rand'],
-		['topic input;',    'my $x=rand;'],
-		['topic input+',    'my $x=rand+5;'],
+		['not mandatory',   'my $x=lc "hi";'],
+		['rand',            'my $x=rand 5;'],
+		['lc topic',        'my @A=map {lc} qw/a b c/'],
+	) {
+		like(($critic->critique(\$$invalid[1]))[0],$failure,$$invalid[0]);
+	}
+};
+
+subtest 'Allowed cases'=>sub {
+	plan tests=>7;
+	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::CodeLayout::RequireParensWithBuiltins',-params=>{});
+	foreach my $valid (
+		['grep/map/rev/sort',  'my @A=reverse sort {$a<=>$b} grep {$_} map {$_} (0,1,2);'],
+		['die',                'die "Hello" if 1;'],
+		['print',              'print STDERR "Hello\n";'],
+		['last',               'foreach (1..5){last}'],
+		['my/our',             'my $x=5; my ($y,$z)=(1,2); our $r=5; our ($s,$t)=(6,7);'],
+		['keys',               'my @K=keys %hash;'],
+		['scalar keys',        'my $n=scalar(keys %hash);'],
+	) {
+		is_deeply([$critic->critique(\$$valid[1])],[],$$valid[0]);
+	}
+};
+
+subtest 'Permitted cases'=>sub {
+	plan tests=>15;
+	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::CodeLayout::RequireParensWithBuiltins',-params=>{});
+	foreach my $valid (
+		['chomp',              'while(<>) { chomp;   $x+=$_ }'],
+		['chomp()',            'while(<>) { chomp(); $x+=$_ }'],
+		['defined',            'if(grep {defined} @A){}'],
+		['defined(hkey)',      'if(grep {defined($h{$_})} @A){}'],
+		['exit',               'exit;'],
+		['exit(2)',            'exit(2);'],
+		['time',               'my $tm=time;'],
+		['time(0)',            'my $tm=time(0);'],
+		['time(tm)',           'my $tm=time(12345);'],
+	) {
+		is_deeply([$critic->critique(\$$valid[1])],[],$$valid[0]);
+	}
+	foreach my $invalid (
+		['chomp',              'chomp $y;'],
+		['chomp',              'chomp $h{key};'],
+		['defined hkey',       'if(grep {defined $h{$_}} @A){}'],
+		['exit 2',             'exit 2;'],
+		['time 0',             'my $tm=time 0;'],
+		['time tm',            'my $tm=time 12345;'],
+	) {
+		like(($critic->critique(\$$invalid[1]))[0],$failure,$$invalid[0]);
+	}
+};
+
+subtest 'Configuration'=>sub {
+	plan tests=>7;
+	my %params=(
+		allow  =>'defined',
+		require=>'defined lc',
+		permit =>'defined lc die',
+	);
+	my $critic=Perl::Critic->new(-profile=>'NONE',-only=>1,-severity=>1);
+	$critic->add_policy(-policy=>'Perl::Critic::Policy::CodeLayout::RequireParensWithBuiltins',-params=>\%params);
+	foreach my $valid (
+		['defined',            'if(grep {defined} @A){}'],
+		['defined(hkey)',      'if(grep {defined($h{$_})} @A){}'],
+		['defined hkey',       'if(grep {defined $h{$_}} @A){}'],
+		['lc',                 'my $x=lc("Hello");'],
+		['die',                'die;'],
+	) {
+		is_deeply([$critic->critique(\$$valid[1])],[],$$valid[0]);
+	}
+	foreach my $invalid (
+		['lc Hello',           'my $x=lc "Hello";'],
+		['die msg',            'die "Goodbye";'],
 	) {
 		like(($critic->critique(\$$invalid[1]))[0],$failure,$$invalid[0]);
 	}


### PR DESCRIPTION
```
PERL5LIB=lib prove ./t/perl/critic/policy/codelayout/requireparenswithbuiltins.t
./t/perl/critic/policy/codelayout/requireparenswithbuiltins.t .. ok
All tests successful.
Files=1, Tests=2,  1 wallclock secs ( 0.04 usr  0.00 sys +  1.04 cusr  0.06 csys =  1.14 CPU)
Result: PASS

perl ./Build.PL
./Build build
sudo ./Build install
./Build test
perl -e 'use Perl::Critic::Grape;'
man Perl::Critic::Grape

PERL5LIB=lib perlcritic -s RequireParensWithBuiltins --list-enabled
# 4 CodeLayout::RequireParensWithBuiltins [core cosmetic]

PERL5LIB=lib perlcritic -s RequireParensWithBuiltins --verbose='%r\n' --quiet $DIR/*.pm
lc $r{$_}
$_ => lc $r{$_}
$record{status} = lc trim($record{status});
$domain = lc $url;
```